### PR TITLE
Slight changes allowing to remove all default logging handlers

### DIFF
--- a/logger.py
+++ b/logger.py
@@ -1,25 +1,35 @@
 #!/usr/bin/env python3
 
-import logging
+import logging as logthings
 import os
 import sys
 
 
-def setup_logging(log_file=None):
-    logger = logging.getLogger()
-    for h in logger.handlers:
-        logger.removeHandler(h)
-    formatter = logging.Formatter(
-        "[%(levelname)s] %(asctime)s, %(funcName)s, %(message)s", "%Y-%m-%d %H:%M:%S")
-    handler = logging.FileHandler(
-        log_file, 'a') if log_file is not None else logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-    logger = logging.getLogger(__name__)
-    logger.addHandler(handler)
-    logger.raiseException = True
-    try:
-        LOGLEVEL = os.environ.get('LOGLEVEL', 'DEBUG').upper()
-        logger.basicConfig(level=LOGLEVEL)
-    except:
-        logger.setLevel(logging.INFO)
-    return logger
+def setup_logging():
+    """Removes the default root handlers if any is set.
+    Changes log level based on environment variable.
+
+    :returns: the_logger
+    :rtype: logging.Logger
+    """
+    level = environ.get('LOGLEVEL')
+
+    if level is not None and isinstance(level, str):
+        logthings.basicConfig(level=level.upper())
+    else:
+        logthings.basicConfig(level='INFO')
+
+    root_logger = logthings.getLogger()
+    for h in root_logger.handlers:
+        root_logger.removeHandler(h)
+    the_logger = logthings.getLogger(__name__)
+
+    if not the_logger.handlers:
+        formatter = logthings.Formatter(
+            "[%(levelname)s] %(asctime)s, %(funcName)s, %(message)s", "%Y-%m-%d %H:%M:%S"
+        )
+        handler = logthings.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+        the_logger.addHandler(handler)
+
+    return the_logger


### PR DESCRIPTION
Slight changes allowing to remove all default logging handlers.
Useful for example if you want to remove the default AWS Lambda log handlers.
Imports logging as logthings and variable named the_logger to avoid any overlap in names.